### PR TITLE
Support discordgo v10/v11a

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -141,6 +141,8 @@ func (d *Discord) Open() (<-chan Message, error) {
 	d.Session.OnMessageUpdate = d.onMessageUpdate
 	d.Session.OnMessageDelete = d.onMessageDelete
 
+	d.Session.Open()
+
 	return d.messageChan, nil
 }
 


### PR DESCRIPTION
Adds Session.Open() to the Discord service Open function so that bruxism will connect to the websocket when using the v10 or v11a of Discordgo.
