### PR TITLE
Improvements to MockService and MockMessage

### DIFF
--- a/mockmessage.go
+++ b/mockmessage.go
@@ -1,7 +1,7 @@
 package bruxism
 
 type MockMessage struct {
-	channel, username, userid, avatar, message, rawMessage string
+	id, channel, username, userid, avatar, message, rawMessage string
 }
 
 func NewMockMessage() *MockMessage {
@@ -39,6 +39,11 @@ func (m *MockMessage) SetRawMessage(message string) *MockMessage {
 	return m
 }
 
+func (m *MockMessage) SetMessageID(messageID string) *MockMessage {
+	m.id = messageID
+	return m
+}
+
 // Satisfy Message interface below
 func (m *MockMessage) Channel() string {
 	return m.channel
@@ -65,7 +70,7 @@ func (m *MockMessage) RawMessage() string {
 }
 
 func (m *MockMessage) MessageID() string {
-	return ""
+	return m.id
 }
 
 func (m *MockMessage) Type() MessageType {

--- a/mockservice.go
+++ b/mockservice.go
@@ -1,17 +1,20 @@
 package bruxism
 
 import (
-	"io"
 	"errors"
+	"io"
 )
 
 // Service is a service interface, wraps a single service such as YouTube or Discord.
 type MockService struct {
 	name, username, userid string
+	messages               chan Message
 }
 
 func NewMockService() *MockService {
-	return &MockService{}
+	return &MockService{
+		messages: make(chan Message, 512),
+	}
 }
 
 func (m *MockService) SetName(name string) *MockService {
@@ -44,7 +47,11 @@ func (s *MockService) UserID() string {
 }
 
 func (s *MockService) Open() (<-chan Message, error) {
-	return nil, errors.New("Not implemented")
+	return s.messages, nil
+}
+
+func (s *MockService) NewMessage(message Message) {
+	s.messages <- message
 }
 
 func (s *MockService) SendFile(channel, name string, r io.Reader) error {


### PR DESCRIPTION
I improved MockService to a point where it's actually usable as a real service, if you feed it data correctly. For example:

~~~
service := bot.NewMockService().SetName("twitch")

twitch := bot.New(db)
twitch.RegisterService(service)
twitch.RegisterPlugin(service, messages.New())
twitch.Open()
~~~

This service doesn't really connect anywhere, but you can feed it MockMessage objects, which will get dispatched to your plugins as well.

~~~
message := bot.NewMockMessage()
message.SetMessageID(strconv.FormatUint(nextID(), 10))
message.SetChannel(channelName)
message.SetUserName(e.Nick)
message.SetUserID(e.Nick)
message.SetMessage(e.Arguments[1])

service.NewMessage(message)
~~~

It was the easiest way to put some pre-existing bot onto bruxism by just providing a faked message pipeline (didn't really care about other features like deletion, moderation, isme, isadmin, etc.).